### PR TITLE
Add shard parsing to  `nodes_stats_parser.py`

### DIFF
--- a/prometheus_es_exporter/nodes_stats_parser.py
+++ b/prometheus_es_exporter/nodes_stats_parser.py
@@ -47,13 +47,15 @@ def parse_block(block, metric=[], labels={}):
                         singular_key = key
                     for n_key, n_value in value.items():
                         if isinstance(n_value, list):
-                            # n_value get passed back into parse_block,
-                            # however parse_block expects a dict, not list
-                            n_value = dict(("shard_id", d) for d in n_value)
-                        if key in excluded_metric_keys:
-                            result.extend(parse_block(n_value, metric=metric, labels=merge_dicts(labels, {singular_key: [n_key]})))
+                            if key == "shards":
+                                n_list = [{"shard_id": d} for d in n_value]
+                                for n_value in n_list:
+                                    result.extend(parse_block(n_value, metric=metric + [key], labels=merge_dicts(labels, {singular_key: [n_key]})))
                         else:
-                            result.extend(parse_block(n_value, metric=metric + [key], labels=merge_dicts(labels, {singular_key: [n_key]})))
+                            if key in excluded_metric_keys:
+                                result.extend(parse_block(n_value, metric=metric, labels=merge_dicts(labels, {singular_key: [n_key]})))
+                            else:
+                                result.extend(parse_block(n_value, metric=metric + [key], labels=merge_dicts(labels, {singular_key: [n_key]})))
                 else:
                     result.extend(parse_block(value, metric=metric + [key], labels=labels))
             elif isinstance(value, list) and key in bucket_list_keys:

--- a/prometheus_es_exporter/nodes_stats_parser.py
+++ b/prometheus_es_exporter/nodes_stats_parser.py
@@ -21,6 +21,8 @@ bucket_dict_keys = [
     'shards',
     'shard_id',
 ]
+# Specifies keys that will be ignored, 
+# when building the metric name
 excluded_metric_keys = [
     'shard_id',
 ]
@@ -48,7 +50,7 @@ def parse_block(block, metric=[], labels={}):
                     for n_key, n_value in value.items():
                         if isinstance(n_value, list):
                             if key == 'shards':
-                                n_list = [{"shard_id": d} for d in n_value]
+                                n_list = [{'shard_id': d} for d in n_value]
                                 for n_value in n_list:
                                     result.extend(parse_block(n_value, metric=metric + [key], labels=merge_dicts(labels, {singular_key: [n_key]})))
                         else:

--- a/prometheus_es_exporter/nodes_stats_parser.py
+++ b/prometheus_es_exporter/nodes_stats_parser.py
@@ -4,14 +4,14 @@ singular_forms = {
     'pools': 'pool',
     'collectors': 'collector',
     'buffer_pools': 'buffer_pool',
-    'shards': 'shard'
+    'shards': 'index',
 }
 excluded_keys = [
     'timestamp',
     'commit',
     'fielddata',
     'is_custom_data_path',
-    'attributes'
+    'attributes',
 ]
 bucket_dict_keys = [
     'pools',
@@ -19,10 +19,10 @@ bucket_dict_keys = [
     'buffer_pools',
     'thread_pool',
     'shards',
-    'shard_id'
+    'shard_id',
 ]
 excluded_metric_keys = [
-    'shard_id'
+    'shard_id',
 ]
 bucket_list_keys = {
     'data': 'path',
@@ -47,7 +47,7 @@ def parse_block(block, metric=[], labels={}):
                         singular_key = key
                     for n_key, n_value in value.items():
                         if isinstance(n_value, list):
-                            if key == "shards":
+                            if key == 'shards':
                                 n_list = [{"shard_id": d} for d in n_value]
                                 for n_value in n_list:
                                     result.extend(parse_block(n_value, metric=metric + [key], labels=merge_dicts(labels, {singular_key: [n_key]})))


### PR DESCRIPTION
We want to be able to track which shards are on which nodes. 

This PR allows the exporter to parse the output about shards, 
when you've specified the 
`--nodes-stats-(fields|level shards|index-metrics)` parameters to output info about shards.
